### PR TITLE
Use stdlib-shims to eliminate deprecation warning

### DIFF
--- a/astring.opam
+++ b/astring.opam
@@ -10,6 +10,7 @@ license: "ISC"
 depends: [
   "dune"
   "ocaml" {>= "4.01.0"}
+  "stdlib-shims"
   "base-bytes"
 ]
 synopsis: "Alternative String module for OCaml"

--- a/src/astring_base.ml
+++ b/src/astring_base.ml
@@ -79,7 +79,7 @@ let of_int32 = Int32.to_string
 let to_int32 s = try Some (Int32.of_string s) with Failure _ -> None
 let of_int64 = Int64.to_string
 let to_int64 s = try Some (Int64.of_string s) with Failure _ -> None
-let of_float = Pervasives.string_of_float
+let of_float = Stdlib.string_of_float
 let to_float s = try Some (float_of_string s) with Failure _ -> None
 
 (*---------------------------------------------------------------------------

--- a/src/astring_char.ml
+++ b/src/astring_char.ml
@@ -25,7 +25,7 @@ let hash c = Hashtbl.hash c
 (* Predicates *)
 
 let equal : t -> t -> bool = fun c0 c1 -> c0 = c1
-let compare : t -> t -> int = fun c0 c1 -> Pervasives.compare c0 c1
+let compare : t -> t -> int = fun c0 c1 -> Stdlib.compare c0 c1
 
 (* Bytes as US-ASCII characters *)
 

--- a/src/astring_sub.ml
+++ b/src/astring_sub.ml
@@ -304,10 +304,10 @@ let compare_bytes (s0, start0, stop0) (s1, start1, stop1) =
   let min_len = if len0 < len1 then len0 else len1 in
   let max_i = min_len - 1 in
   let rec loop i =
-    if i > max_i then Pervasives.compare len0 len1 else
+    if i > max_i then Stdlib.compare len0 len1 else
     let c0 = sunsafe_get s0 (start0 + i) in
     let c1 = sunsafe_get s1 (start1 + i) in
-    let cmp = Pervasives.compare c0 c1 in
+    let cmp = Stdlib.compare c0 c1 in
     if cmp <> 0 then cmp else
     loop (i + 1)
   in
@@ -318,7 +318,7 @@ let equal (s0, start0, stop0) (s1, start1, stop1) =
   if s0 != s1 then invalid_arg err_base else
   eq_pos start0 start1 && eq_pos stop0 stop1
 
-let compare_pos : int -> int -> int = Pervasives.compare
+let compare_pos : int -> int -> int = Stdlib.compare
 let compare (s0, start0, stop0) (s1, start1, stop1) =
   if s0 != s1 then invalid_arg err_base else
   let c = compare_pos start0 start1 in

--- a/src/dune
+++ b/src/dune
@@ -3,6 +3,7 @@
  (public_name astring)
  (modules astring_unsafe astring_base astring_escape astring_char astring_sub
    astring_string astring)
+ (libraries stdlib-shims)
  (flags :standard -w -27)
  (wrapped false))
 


### PR DESCRIPTION
Not sure how to format this is a pull request - `duniverse-master` still has `jbuild` files?